### PR TITLE
feat: add privacy manifest

### DIFF
--- a/ios/PrivacyInfo.xcprivacy
+++ b/ios/PrivacyInfo.xcprivacy
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDiagnosticData</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>1C8F.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/ios/SendbirdNotificationHelper.m
+++ b/ios/SendbirdNotificationHelper.m
@@ -11,7 +11,7 @@
 
 static NSString* SBNExtensionGroup = @"group.name";
 static NSString*const SBNDeviceTokenKey = @"sendbird.device-token";
-static NSString*const SBNExtensionVersion = @"0.0.1";
+static NSString*const SBNExtensionVersion = @"1.0.0";
 
 // Mark: - exports
 //

--- a/sendbird-notifications-extension.podspec
+++ b/sendbird-notifications-extension.podspec
@@ -14,4 +14,5 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/sendbird/react-native-push-extension.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm}"
+  s.resource_bundles = { "sendbird-notifications-extension_privacy" => "ios/PrivacyInfo.xcprivacy" }
 end


### PR DESCRIPTION
[CLNP-2839]

- Other Diagnostic Data
  - App Functionality
- User Defaults
  - Access info from same App Group

[CLNP-2839]: https://sendbird.atlassian.net/browse/CLNP-2839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<img width="1012" alt="image" src="https://github.com/sendbird/react-native-push-extension/assets/26326015/04ff90ba-a1db-4663-ac24-8612f9033a14">
